### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "devDependencies": {
-    "@springworks/test-harness": "^1.0.3",
-    "babel": "^5.8.23",
-    "babel-eslint": "^4.1.1",
-    "coveralls": "^2.11.4",
-    "eslint": "^1.3.1",
-    "eslint-config-springworks": "^2.6.0",
-    "eslint-plugin-mocha": "^0.5.1",
-    "istanbul": "^0.3.19",
-    "mocha": "^2.3.0"
+    "@springworks/test-harness": "1.0.3",
+    "babel": "5.8.23",
+    "babel-eslint": "4.1.3",
+    "coveralls": "2.11.4",
+    "eslint": "1.5.1",
+    "eslint-config-springworks": "2.6.1",
+    "eslint-plugin-mocha": "0.5.1",
+    "istanbul": "0.3.21",
+    "mocha": "2.3.3"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,6 @@
     "npm": ">=2.7.0"
   },
   "dependencies": {
-    "xml2js": "^0.4.11"
+    "xml2js": "0.4.12"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
