### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - '4'
+  - '4.4.0'
   - '6'
   - '7'
+  - '8'
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
We should run tests against current live node versions as well. 4.4.0 is the one on our EC2 instances as well as teamcity, and 8.x is running in Docker.