### PR TITLE
feat: don't error on missing fixtures

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -112,8 +112,8 @@ describe('loadParsedJson', () => {
 
   describe('with a path to a file that does not exist', () => {
 
-    it('should throw an error', () => {
-      loader.loadParsedJson.bind(null, '.', 'does-not-exist').should.throw(/ENOENT/);
+    it('should not throw an error', () => {
+      loader.loadParsedJson.bind(null, '.', 'does-not-exist').should.not.throw();
     });
 
   });
@@ -151,8 +151,8 @@ describe('loadString', () => {
 
   describe('with a path to a file that does not exist', () => {
 
-    it('should throw an error', () => {
-      loader.loadString.bind(null, '.', 'does-not-exist').should.throw();
+    it('should not throw an error', () => {
+      loader.loadString.bind(null, '.', 'does-not-exist').should.not.throw();
     });
 
   });


### PR DESCRIPTION
BREAKING CHANGE: Errors are no longer thrown for missing fixtures.

The primary use of this package is to wire up our static-api servers using https://github.com/Springworks/node-static-api-server which now supports output validation. This means that if we are expecting a fixture for a specific route, it will show up as a validation error. Throwing on every error only clutters the logging for missing fixtures which aren't actually missing because the endpoint doesn't return anything.