### PR TITLE
feat: Throw on missing fixture

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,13 @@ import { merge } from 'lodash';
 
 const cache = Object.create(null);
 
+export class MissingFixtureError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MissingFixtureError';
+  }
+}
+
 export function create(...fixture_base_path) {
   const base_path = join(...fixture_base_path);
   let shadow_cache = {};
@@ -72,9 +79,8 @@ function getCachedFileContents(base_path, fixture_path, filename) {
     return contents;
   }
   catch (err) {
-    // Handle missing fixtures silently
     if (err.code === 'ENOENT') {
-      return undefined;
+      throw new MissingFixtureError(`Could not load ${file_path}`);
     }
     throw err;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import { create as createFixtureLoader } from '../src';
+import { create as createFixtureLoader, MissingFixtureError } from '../src';
 
 describe('test/test.js', () => {
 
@@ -112,8 +112,8 @@ describe('loadParsedJson', () => {
 
   describe('with a path to a file that does not exist', () => {
 
-    it('should not throw an error', () => {
-      loader.loadParsedJson.bind(null, '.', 'does-not-exist').should.not.throw();
+    it('should throw a MissingFixtureError', () => {
+      loader.loadParsedJson.bind(null, '.', 'does-not-exist').should.throw(MissingFixtureError);
     });
 
   });
@@ -151,8 +151,9 @@ describe('loadString', () => {
 
   describe('with a path to a file that does not exist', () => {
 
-    it('should not throw an error', () => {
-      loader.loadString.bind(null, '.', 'does-not-exist').should.not.throw();
+
+    it('should throw a MissingFixtureError', () => {
+      loader.loadParsedJson.bind(null, '.', 'does-not-exist').should.throw(MissingFixtureError);
     });
 
   });


### PR DESCRIPTION
Let's leave this to the consumer to decide what to do in this case. Returning an empty object as JSON on a missing fixture was problematic for routes which shouldn't return any body.